### PR TITLE
Fix video nav colors and left panel height consistency

### DIFF
--- a/src/components/ai-studio/AIStudioBase.tsx
+++ b/src/components/ai-studio/AIStudioBase.tsx
@@ -189,7 +189,7 @@ export const AIStudioBase = ({
         </div>
 
         <div className="flex-1 overflow-hidden">
-          <ScrollArea className="h-[calc(100vh-340px)] px-3 lg:px-4">
+          <ScrollArea className="h-full px-3 lg:px-4">
             <div className="space-y-3 pb-4">
             {filteredProjects.map((project) => {
               const traditionalModel = traditionalModels.find(m => m.key === project.type);

--- a/src/components/ai-studio/AIStudioBase.tsx
+++ b/src/components/ai-studio/AIStudioBase.tsx
@@ -120,7 +120,7 @@ export const AIStudioBase = ({
 
   // Project History Sidebar Component
   const ProjectHistorySidebar = ({ onClose }: { onClose?: () => void }) => (
-    <div className="h-[calc(100vh-64px)] flex flex-col">
+    <div className="h-full flex flex-col">
       {/* Sidebar Header */}
       <div className="p-4 lg:p-6 border-b flex-shrink-0">
         <div className="flex items-center gap-3 mb-4">

--- a/src/pages/VideoProcessing.tsx
+++ b/src/pages/VideoProcessing.tsx
@@ -325,7 +325,7 @@ const VideoProcessing = () => {
             placeholder="Search videos..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="pl-9 text-sm border-purple-200/50 focus:border-purple-400"
+            className="pl-9 text-sm"
           />
         </div>
       </div>

--- a/src/pages/VideoProcessing.tsx
+++ b/src/pages/VideoProcessing.tsx
@@ -318,7 +318,7 @@ const VideoProcessing = () => {
       </div>
 
       {/* Search */}
-      <div className="p-3 lg:p-4 border-b border-purple-200/30 dark:border-purple-800/30 flex-shrink-0">
+      <div className="p-3 lg:p-4 border-b flex-shrink-0">
         <div className="relative">
           <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input

--- a/src/pages/VideoProcessing.tsx
+++ b/src/pages/VideoProcessing.tsx
@@ -344,7 +344,7 @@ const VideoProcessing = () => {
             {filteredProjects.map((project) => (
               <Card 
                 key={project.id} 
-                className="cursor-pointer hover:bg-white/80 dark:hover:bg-gray-800/80 transition-all duration-200 hover:shadow-lg border-purple-200/50 dark:border-purple-800/50"
+                className="cursor-pointer hover:bg-muted/50 transition-colors"
                 onClick={() => onClose?.()}
               >
                 <CardContent className="p-3 lg:p-4">

--- a/src/pages/VideoProcessing.tsx
+++ b/src/pages/VideoProcessing.tsx
@@ -311,7 +311,7 @@ const VideoProcessing = () => {
           </div>
         </div>
         
-        <Button className="w-full gap-2 text-sm bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600" onClick={() => {setActiveTab(null); onClose?.();}}>
+        <Button className="w-full gap-2 text-sm" onClick={() => {setActiveTab(null); onClose?.();}}>
           <Plus className="h-4 w-4" />
           New Video
         </Button>
@@ -701,7 +701,7 @@ const VideoProcessing = () => {
                             className="w-full group-hover:bg-purple-500 group-hover:text-white transition-all duration-200 text-purple-600 hover:text-white"
                           >
                             <Play className="mr-2 h-4 w-4" />
-                            Use This Prompt ��
+                            Use This Prompt →
                           </Button>
                         </div>
                       </CardContent>

--- a/src/pages/VideoProcessing.tsx
+++ b/src/pages/VideoProcessing.tsx
@@ -680,7 +680,7 @@ const VideoProcessing = () => {
                             <div className="text-3xl">{prompt.icon}</div>
                             <div className="flex-1">
                               <div className="flex items-center gap-2 mb-2">
-                                <Badge variant="outline" className="text-xs border-purple-300 text-purple-600">
+                                <Badge variant="outline" className="text-xs">
                                   {prompt.category}
                                 </Badge>
                                 <Badge variant="outline" className="text-xs">

--- a/src/pages/VideoProcessing.tsx
+++ b/src/pages/VideoProcessing.tsx
@@ -306,7 +306,7 @@ const VideoProcessing = () => {
             <Film className="h-4 w-4 lg:h-5 lg:w-5 text-primary-foreground" />
           </div>
           <div>
-            <h2 className="font-semibold text-base lg:text-lg bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">Video Studio</h2>
+            <h2 className="font-semibold text-base lg:text-lg">Video Studio</h2>
             <p className="text-xs lg:text-sm text-muted-foreground">Recent Creations</p>
           </div>
         </div>
@@ -701,7 +701,7 @@ const VideoProcessing = () => {
                             className="w-full group-hover:bg-purple-500 group-hover:text-white transition-all duration-200 text-purple-600 hover:text-white"
                           >
                             <Play className="mr-2 h-4 w-4" />
-                            Use This Prompt →
+                            Use This Prompt ��
                           </Button>
                         </div>
                       </CardContent>

--- a/src/pages/VideoProcessing.tsx
+++ b/src/pages/VideoProcessing.tsx
@@ -330,17 +330,18 @@ const VideoProcessing = () => {
         </div>
       </div>
 
-      {/* Project History */}
-      <div className="flex-1 min-h-0">
+      {/* Project History - Scrollable with full remaining height */}
+      <div className="flex-1 min-h-0 overflow-hidden">
         <div className="p-3 lg:p-4 pb-2 flex-shrink-0">
           <div className="flex items-center gap-2">
             <History className="h-4 w-4 text-muted-foreground" />
             <h3 className="font-medium text-sm">Recent Videos</h3>
           </div>
         </div>
-        
-        <ScrollArea className="h-full px-3 lg:px-4">
-          <div className="space-y-3 pb-4">
+
+        <div className="flex-1 overflow-hidden">
+          <ScrollArea className="h-full px-3 lg:px-4">
+            <div className="space-y-3 pb-4">
             {filteredProjects.map((project) => (
               <Card 
                 key={project.id} 
@@ -389,8 +390,9 @@ const VideoProcessing = () => {
                 <p className="text-sm text-muted-foreground">No videos found</p>
               </div>
             )}
-          </div>
-        </ScrollArea>
+            </div>
+          </ScrollArea>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/VideoProcessing.tsx
+++ b/src/pages/VideoProcessing.tsx
@@ -438,7 +438,7 @@ const VideoProcessing = () => {
               onClick={() => setActiveTab(null)}
               size="sm"
               variant="outline"
-              className="gap-2 border-purple-300 text-purple-600 hover:bg-purple-50"
+              className="gap-2"
             >
               <Plus className="h-4 w-4" />
               New

--- a/src/pages/VideoProcessing.tsx
+++ b/src/pages/VideoProcessing.tsx
@@ -334,8 +334,8 @@ const VideoProcessing = () => {
       <div className="flex-1 min-h-0">
         <div className="p-3 lg:p-4 pb-2 flex-shrink-0">
           <div className="flex items-center gap-2">
-            <History className="h-4 w-4 text-purple-500" />
-            <h3 className="font-medium text-sm text-purple-700 dark:text-purple-300">Recent Videos</h3>
+            <History className="h-4 w-4 text-muted-foreground" />
+            <h3 className="font-medium text-sm">Recent Videos</h3>
           </div>
         </div>
         

--- a/src/pages/VideoProcessing.tsx
+++ b/src/pages/VideoProcessing.tsx
@@ -430,7 +430,7 @@ const VideoProcessing = () => {
                 <Menu className="h-5 w-5" />
               </Button>
               <div>
-                <h1 className="font-semibold text-lg bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">Video Studio</h1>
+                <h1 className="font-semibold text-lg">Video Studio</h1>
                 <p className="text-xs text-muted-foreground">AI Video Generation</p>
               </div>
             </div>

--- a/src/pages/VideoProcessing.tsx
+++ b/src/pages/VideoProcessing.tsx
@@ -300,7 +300,7 @@ const VideoProcessing = () => {
   const ProjectHistorySidebar = ({ onClose }: { onClose?: () => void }) => (
     <div className="h-full flex flex-col">
       {/* Sidebar Header */}
-      <div className="p-4 lg:p-6 border-b border-purple-200/30 dark:border-purple-800/30 flex-shrink-0">
+      <div className="p-4 lg:p-6 border-b flex-shrink-0">
         <div className="flex items-center gap-3 mb-4">
           <div className="p-2 rounded-xl bg-gradient-to-r from-purple-500 to-pink-500">
             <Film className="h-4 w-4 lg:h-5 lg:w-5 text-white" />

--- a/src/pages/VideoProcessing.tsx
+++ b/src/pages/VideoProcessing.tsx
@@ -386,7 +386,7 @@ const VideoProcessing = () => {
             
             {filteredProjects.length === 0 && (
               <div className="text-center py-8">
-                <Film className="h-8 w-8 lg:h-12 lg:w-12 text-purple-300 mx-auto mb-3" />
+                <Film className="h-8 w-8 lg:h-12 lg:w-12 text-muted-foreground/50 mx-auto mb-3" />
                 <p className="text-sm text-muted-foreground">No videos found</p>
               </div>
             )}

--- a/src/pages/VideoProcessing.tsx
+++ b/src/pages/VideoProcessing.tsx
@@ -349,7 +349,7 @@ const VideoProcessing = () => {
               >
                 <CardContent className="p-3 lg:p-4">
                   <div className="flex items-start gap-3">
-                    <div className="w-12 h-8 bg-gradient-to-br from-purple-400 to-pink-400 rounded-lg flex items-center justify-center text-white text-lg flex-shrink-0">
+                    <div className="w-12 h-8 bg-gradient-to-r from-primary to-primary/80 rounded-lg flex items-center justify-center text-primary-foreground text-lg flex-shrink-0">
                       {project.thumbnail}
                     </div>
                     <div className="flex-1 min-w-0">

--- a/src/pages/VideoProcessing.tsx
+++ b/src/pages/VideoProcessing.tsx
@@ -360,7 +360,7 @@ const VideoProcessing = () => {
                           <Badge className={`text-xs ${getStatusColor(project.status)}`}>
                             {project.status}
                           </Badge>
-                          <Badge variant="outline" className="text-xs border-purple-300 text-purple-600">
+                          <Badge variant="outline" className="text-xs">
                             {project.resolution}
                           </Badge>
                           <Badge variant="outline" className="text-xs">

--- a/src/pages/VideoProcessing.tsx
+++ b/src/pages/VideoProcessing.tsx
@@ -406,7 +406,7 @@ const VideoProcessing = () => {
 
         {/* Mobile Sidebar */}
         <Sheet open={isMobileSidebarOpen} onOpenChange={setIsMobileSidebarOpen}>
-          <SheetContent side="left" className="w-full sm:w-80 p-0">
+          <SheetContent side="left" className="w-full sm:w-80 p-0 h-full overflow-hidden">
             <SheetHeader className="sr-only">
               <SheetTitle>Video Projects</SheetTitle>
             </SheetHeader>

--- a/src/pages/VideoProcessing.tsx
+++ b/src/pages/VideoProcessing.tsx
@@ -400,7 +400,7 @@ const VideoProcessing = () => {
       <Navbar />
       <div className="flex h-[calc(100vh-64px)] relative">
         {/* Desktop Sidebar */}
-        <div className="w-80 border-r border-purple-200/50 hidden lg:block">
+        <div className="w-80 border-r bg-card/30 backdrop-blur-sm hidden lg:block h-full overflow-hidden">
           <ProjectHistorySidebar />
         </div>
 

--- a/src/pages/VideoProcessing.tsx
+++ b/src/pages/VideoProcessing.tsx
@@ -302,8 +302,8 @@ const VideoProcessing = () => {
       {/* Sidebar Header */}
       <div className="p-4 lg:p-6 border-b flex-shrink-0">
         <div className="flex items-center gap-3 mb-4">
-          <div className="p-2 rounded-xl bg-gradient-to-r from-purple-500 to-pink-500">
-            <Film className="h-4 w-4 lg:h-5 lg:w-5 text-white" />
+          <div className="p-2 rounded-xl bg-gradient-to-r from-primary to-primary/80">
+            <Film className="h-4 w-4 lg:h-5 lg:w-5 text-primary-foreground" />
           </div>
           <div>
             <h2 className="font-semibold text-base lg:text-lg bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">Video Studio</h2>

--- a/src/pages/VideoProcessing.tsx
+++ b/src/pages/VideoProcessing.tsx
@@ -298,7 +298,7 @@ const VideoProcessing = () => {
 
   // Project History Sidebar Component
   const ProjectHistorySidebar = ({ onClose }: { onClose?: () => void }) => (
-    <div className="h-full flex flex-col bg-gradient-to-b from-purple-50/50 to-pink-50/50 dark:from-purple-950/10 dark:to-pink-950/10">
+    <div className="h-full flex flex-col">
       {/* Sidebar Header */}
       <div className="p-4 lg:p-6 border-b border-purple-200/30 dark:border-purple-800/30 flex-shrink-0">
         <div className="flex items-center gap-3 mb-4">

--- a/src/pages/VideoProcessing.tsx
+++ b/src/pages/VideoProcessing.tsx
@@ -419,7 +419,7 @@ const VideoProcessing = () => {
         {/* Main Content Area */}
         <div className="flex-1 flex flex-col min-w-0">
           {/* Mobile Header */}
-          <div className="lg:hidden border-b border-purple-200/50 bg-gradient-to-r from-purple-50/50 to-pink-50/50 backdrop-blur-sm p-4 flex items-center justify-between">
+          <div className="lg:hidden border-b bg-card/50 backdrop-blur-sm p-4 flex items-center justify-between">
             <div className="flex items-center gap-3">
               <Button 
                 variant="ghost" 

--- a/src/pages/VideoProcessing.tsx
+++ b/src/pages/VideoProcessing.tsx
@@ -398,7 +398,7 @@ const VideoProcessing = () => {
   );
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-50/30 via-background to-pink-50/30">
+    <div className="min-h-screen bg-background">
       <Navbar />
       <div className="flex h-[calc(100vh-64px)] relative">
         {/* Desktop Sidebar */}


### PR DESCRIPTION
## Purpose
The user requested two main improvements to the video section:
1. Reduce excessive colors in the Video navigation section to match the simpler styling used in Audio and Text sections
2. Fix the left panel height issue in Audio and Text sections to match the Video section's limited height design for better alignment with the main content area

## Code changes
- **Removed purple/pink gradient styling** from Video section sidebar to match neutral theme used in Audio/Text sections
- **Standardized color scheme** by replacing custom purple/pink colors with theme-consistent primary colors and muted variants
- **Fixed left panel height** by updating height classes from fixed calculations to `h-full` for proper flex container behavior
- **Improved scroll container structure** to ensure proper height constraints and scrolling behavior across all sections
- **Unified styling approach** across Video, Audio, and Text sections for consistent user experience

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/56bf92e0190c4938a152d5361fdfd794/zen-works)

👀 [Preview Link](https://56bf92e0190c4938a152d5361fdfd794-zen-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>56bf92e0190c4938a152d5361fdfd794</projectId>-->
<!--<branchName>zen-works</branchName>-->